### PR TITLE
add adoptopenjdk 8/9 casks

### DIFF
--- a/Casks/adoptopenjdk8.rb
+++ b/Casks/adoptopenjdk8.rb
@@ -1,0 +1,48 @@
+cask 'adoptopenjdk8' do
+  version '8,181:b13'
+  sha256 'ce57fbf5c8b392a09a130e90f78f9d37de8fbbb7ec7687cda735030738c0e985'
+
+  # github.com/AdoptOpenJDK was verified as official when first introduced to the cask
+  url "https://github.com/AdoptOpenJDK/openjdk#{version.before_comma}-binaries/releases/download/jdk#{version.before_comma}u#{version.after_comma.before_colon}-#{version.after_colon}/OpenJDK#{version.before_comma}U-jdk_x64_mac_hotspot_#{version.before_comma}u#{version.after_comma.before_colon}#{version.after_colon}.tar.gz"
+  appcast "https://github.com/adoptopenjdk/openjdk#{version.before_comma}-binaries/releases.atom"
+  name 'AdoptOpenJDK 8'
+  homepage 'https://adoptopenjdk.net/'
+
+  postflight do
+    system_command '/bin/mv',
+                   args: ['-f', '--', "#{staged_path}/jdk#{version.before_comma}u#{version.after_comma.before_colon}-#{version.after_colon}",
+                          "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jdk"],
+                   sudo: true
+
+    system_command '/bin/mkdir',
+                   args: ['-p', '--', '/Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home/bundle/Libraries'],
+                   sudo: true
+
+    system_command '/bin/ln',
+                   args: ['-nsf', '--', "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jdk/Contents/Home/lib/server/libjvm.dylib",
+                          "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jdk/Contents/Home/bundle/Libraries/libserver.dylib"],
+                   sudo: true
+
+    system_command '/usr/libexec/PlistBuddy',
+                   args: ['-c', "Set :CFBundleGetInfoString AdoptOpenJDK 1.#{version.before_comma}.0_#{version.after_comma.before_colon}", "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jdk/Contents/Info.plist"],
+                   sudo: true
+
+    system_command '/usr/libexec/PlistBuddy',
+                   args: ['-c', "Set :CFBundleIdentifier net.adoptopenjdk.#{version.before_comma}.jdk", "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jdk/Contents/Info.plist"],
+                   sudo: true
+
+    system_command '/usr/libexec/PlistBuddy',
+                   args: ['-c', "Set :CFBundleName AdoptOpenJDK #{version.before_comma}", "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jdk/Contents/Info.plist"],
+                   sudo: true
+
+    system_command '/usr/libexec/PlistBuddy',
+                   args: ['-c', "Set :JavaVM:JVMPlatformVersion 1.#{version.before_comma}.0_#{version.after_comma.before_colon}", "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jdk/Contents/Info.plist"],
+                   sudo: true
+
+    system_command '/usr/libexec/PlistBuddy',
+                   args: ['-c', 'Set :JavaVM:JVMVendor AdoptOpenJDK', "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jdk/Contents/Info.plist"],
+                   sudo: true
+  end
+
+  uninstall delete: "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jdk"
+end

--- a/Casks/adoptopenjdk9.rb
+++ b/Casks/adoptopenjdk9.rb
@@ -1,0 +1,48 @@
+cask 'adoptopenjdk9' do
+  version '9,181'
+  sha256 'bbe348baab3cca097b77f7fff6c8465858e642ad42c5851bde33a1553ca12653'
+
+  # github.com/AdoptOpenJDK was verified as official when first introduced to the cask
+  url "https://github.com/AdoptOpenJDK/openjdk#{version.before_comma}-binaries/releases/download/jdk-#{version.before_comma}%2B#{version.after_comma}/OpenJDK#{version.before_comma}U-jdk_x64_mac_hotspot_#{version.before_comma}_#{version.after_comma}.tar.gz"
+  appcast "https://github.com/adoptopenjdk/openjdk#{version.before_comma}-binaries/releases.atom"
+  name 'AdoptOpenJDK 9'
+  homepage 'https://adoptopenjdk.net/'
+
+  postflight do
+    system_command '/bin/mv',
+                   args: ['-f', '--', "#{staged_path}/jdk-#{version.before_comma}+#{version.after_comma}",
+                          "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jdk"],
+                   sudo: true
+
+    system_command '/bin/mkdir',
+                   args: ['-p', '--', "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jdk/Contents/Home/bundle/Libraries"],
+                   sudo: true
+
+    system_command '/bin/ln',
+                   args: ['-nsf', '--', "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jdk/Contents/Home/lib/server/libjvm.dylib",
+                          "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jdk/Contents/Home/bundle/Libraries/libserver.dylib"],
+                   sudo: true
+
+    system_command '/usr/libexec/PlistBuddy',
+                   args: ['-c', "Set :CFBundleGetInfoString AdoptOpenJDK #{version.before_comma}+#{version.after_comma}", "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jdk/Contents/Info.plist"],
+                   sudo: true
+
+    system_command '/usr/libexec/PlistBuddy',
+                   args: ['-c', "Set :CFBundleIdentifier net.adoptopenjdk.#{version.before_comma}.jdk", "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jdk/Contents/Info.plist"],
+                   sudo: true
+
+    system_command '/usr/libexec/PlistBuddy',
+                   args: ['-c', "Set :CFBundleName AdoptOpenJDK #{version.before_comma}", "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jdk/Contents/Info.plist"],
+                   sudo: true
+
+    system_command '/usr/libexec/PlistBuddy',
+                   args: ['-c', "Set :JavaVM:JVMPlatformVersion #{version.before_comma}.#{version.after_comma}", "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jdk/Contents/Info.plist"],
+                   sudo: true
+
+    system_command '/usr/libexec/PlistBuddy',
+                   args: ['-c', 'Set :JavaVM:JVMVendor AdoptOpenJDK', "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jdk/Contents/Info.plist"],
+                   sudo: true
+  end
+
+  uninstall delete: "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jdk"
+end

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # AdoptOpenJDK - HomeBrew TAP
 
-## THIS BREW TAP IS BEING DEPRECATED!
-
 For the following OpenJDK versions please now use `brew cask`:
 
 ### Latest:
@@ -9,7 +7,7 @@ For the following OpenJDK versions please now use `brew cask`:
 
 ### Other Versions:
 ```bash
-brew tap homebrew/cask-versions
+brew tap AdoptOpenJDK/openjdk
 brew cask install <version>
 ```
 


### PR DESCRIPTION
Remove the deprecation notice from the readme.

Add casks that will be removed in https://github.com/Homebrew/homebrew-cask-versions/pull/6453