### PR TITLE
Removes brew cask install openjdk11 from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,3 @@ brew cask install <version>
 - OpenJDK8 - `adoptopenjdk8`
 - OpenJDK9 - `adoptopenjdk9`
 - OpenJDK10 - `adoptopenjdk10`
-- OpenJDK11 - `adoptopenjdk11`


### PR DESCRIPTION
This doesn't work, no sense getting people's hopes up.