### PR TITLE
Update adoptopenjdk8.rb to jdk8u202-b08

### DIFF
--- a/Casks/adoptopenjdk8.rb
+++ b/Casks/adoptopenjdk8.rb
@@ -1,6 +1,6 @@
 cask 'adoptopenjdk8' do
-  version '8,192:b12'
-  sha256 'cde59e884c473c3be52400bfad14b3ea1d8c42c994649f064ef335a727a36594'
+  version '8,202:b08'
+  sha256 '35e8f9b18f6c7b627dba13a4c6f45e6266552ccd7156043d92391443db0d60d6'
 
   # github.com/AdoptOpenJDK was verified as official when first introduced to the cask
   url "https://github.com/AdoptOpenJDK/openjdk#{version.before_comma}-binaries/releases/download/jdk#{version.before_comma}u#{version.after_comma.before_colon}-#{version.after_colon}/OpenJDK#{version.before_comma}U-jdk_x64_mac_hotspot_#{version.before_comma}u#{version.after_comma.before_colon}#{version.after_colon}.tar.gz"

--- a/Casks/adoptopenjdk8.rb
+++ b/Casks/adoptopenjdk8.rb
@@ -10,8 +10,10 @@ cask 'adoptopenjdk8' do
 
   postflight do
     system_command '/bin/mv',
-                   args: ['-f', '--', "#{staged_path}/jdk#{version.before_comma}u#{version.after_comma.before_colon}-#{version.after_colon}",
-                          "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jdk"],
+                   args: [
+                           '-f', '--', "#{staged_path}/jdk#{version.before_comma}u#{version.after_comma.before_colon}-#{version.after_colon}",
+                           "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jdk"
+                         ],
                    sudo: true
 
     system_command '/bin/mkdir',
@@ -19,8 +21,10 @@ cask 'adoptopenjdk8' do
                    sudo: true
 
     system_command '/bin/ln',
-                   args: ['-nsf', '--', "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jdk/Contents/Home/lib/server/libjvm.dylib",
-                          "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jdk/Contents/Home/bundle/Libraries/libserver.dylib"],
+                   args: [
+                           '-nsf', '--', "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jdk/Contents/Home/lib/server/libjvm.dylib",
+                           "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jdk/Contents/Home/bundle/Libraries/libserver.dylib"
+                         ],
                    sudo: true
 
     system_command '/usr/libexec/PlistBuddy',


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
