### PR TITLE
Add adoptopenjdk11-jre.rb

### DIFF
--- a/Casks/adoptopenjdk11-jre.rb
+++ b/Casks/adoptopenjdk11-jre.rb
@@ -1,0 +1,82 @@
+cask 'adoptopenjdk11-jre' do
+  version '11.0.2,7'
+  sha256 '53febef8465b4e901309e5b91172a3f91ea3052ba20822abccd1ccb8c37e83a2'
+
+  # github.com/AdoptOpenJDK was verified as official when first introduced to the cask
+  url "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-#{version.before_comma}%2B#{version.after_comma}/OpenJDK11U-jre_x64_mac_hotspot_#{version.before_comma}_#{version.after_comma}.tar.gz"
+  appcast 'https://github.com/adoptopenjdk/openjdk11-binaries/releases.atom'
+  name 'AdoptOpenJDK'
+  homepage 'https://adoptopenjdk.net/'
+
+  postflight do
+    system_command '/bin/mv',
+                   args: [
+                           '-f', '--', "#{staged_path}/jdk-#{version.before_comma}+#{version.after_comma}-jre",
+                           "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jre"
+                         ],
+                   sudo: true
+
+    system_command '/bin/mkdir',
+                   args: ['-p', '--', "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jre/Contents/Home/bundle/Libraries"],
+                   sudo: true
+
+    system_command '/bin/ln',
+                   args: [
+                           '-nsf', '--',
+                           "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jre/Contents/Home/lib/server/libjvm.dylib",
+                           "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jre/Contents/Home/bundle/Libraries/libserver.dylib"
+                         ],
+                   sudo: true
+
+    system_command '/usr/libexec/PlistBuddy',
+                   args: [
+                           '-c', "Set :CFBundleGetInfoString AdoptOpenJDK (JRE) #{version.before_comma}+#{version.after_comma}",
+                           "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jre/Contents/Info.plist"
+                         ],
+                   sudo: true
+
+    system_command '/usr/libexec/PlistBuddy',
+                   args: [
+                           '-c', "Set :CFBundleIdentifier net.adoptopenjdk.#{version.before_comma}.jre",
+                           "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jre/Contents/Info.plist"
+                         ],
+                   sudo: true
+
+    system_command '/usr/libexec/PlistBuddy',
+                   args: [
+                           '-c', "Set :CFBundleName AdoptOpenJDK (JRE) #{version.before_comma}",
+                           "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jre/Contents/Info.plist"
+                         ],
+                   sudo: true
+
+    system_command '/usr/libexec/PlistBuddy',
+                   args: [
+                           '-c', "Set :JavaVM:JVMPlatformVersion #{version.before_comma}.#{version.after_comma}",
+                           "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jre/Contents/Info.plist"
+                         ],
+                   sudo: true
+
+    system_command '/usr/libexec/PlistBuddy',
+                   args: [
+                           '-c', 'Set :JavaVM:JVMVendor AdoptOpenJDK',
+                           "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jre/Contents/Info.plist"
+                         ],
+                   sudo: true
+
+    system_command '/usr/libexec/PlistBuddy',
+                   args: [
+                           '-c', 'Add :JavaVM:JVMCapabilities array',
+                           "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jre/Contents/Info.plist"
+                         ],
+                   sudo: true
+
+    system_command '/usr/libexec/PlistBuddy',
+                   args: [
+                           '-c', 'Add :JavaVM:JVMCapabilities:0 string CommandLine',
+                           "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jre/Contents/Info.plist"
+                         ],
+                   sudo: true
+  end
+
+  uninstall delete: "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jre"
+end

--- a/README.md
+++ b/README.md
@@ -16,4 +16,5 @@ brew cask install <version>
 - OpenJDK9 - `adoptopenjdk9`
 - OpenJDK10 - `adoptopenjdk10`
 - OpenJDK11 - `adoptopenjdk11`
-- OpenJDK11 w/ OpenJ9 JVM - `adoptopenjdk11-openj9`
+- OpenJDK11, JRE only - `adoptopenjdk11-jre`
+- OpenJDK11, with OpenJ9 JVM - `adoptopenjdk11-openj9`


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [x] Named the cask in a similar way to the existing casks.
- [x] Added new cask to the README.md
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.

To solve issue https://github.com/AdoptOpenJDK/homebrew-openjdk/issues/24, here is a cask for the JRE version of AdoptOpenJDK 11. The install location is:
`/Library/Java/JavaVirtualMachines/adoptopenjdk-11.0.2.jre/Contents/Home`

I've added the following entry to the `Info.plist`:
```
    <key>JVMCapabilities</key>
    <array>
        <string>CommandLine</string>
    </array>
```
This allow to find the JRE through `/usr/libexec/java_home -V`.

Please review this cask and I will add the other JREs.