### PR TITLE
Fixes AdoptOpenJDK/homebrew-openjdk/issues/77

### DIFF
--- a/Casks/adoptopenjdk11-jre.rb
+++ b/Casks/adoptopenjdk11-jre.rb
@@ -1,23 +1,25 @@
 cask 'adoptopenjdk11-jre' do
-  version '11.0.2,9'
+  version '11,0.2:9'
   sha256 '7e70784f7833751b63cee9e197230877a4059b178a24858261f834ea39b29fd5'
 
   # github.com/AdoptOpenJDK was verified as official when first introduced to the cask
-  url "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-#{version.before_comma}%2B#{version.after_comma}/OpenJDK11U-jre_x64_mac_hotspot_#{version.before_comma}_#{version.after_comma}.tar.gz"
+  url "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-#{version.before_comma}.#{version.after_comma.before_colon}%2B#{version.after_colon}/OpenJDK11U-jre_x64_mac_hotspot_#{version.before_comma}.#{version.after_comma.before_colon}_#{version.after_colon}.tar.gz"
   appcast 'https://github.com/adoptopenjdk/openjdk11-binaries/releases.atom'
-  name 'AdoptOpenJDK'
+  name 'AdoptOpenJDK 11 (JRE)'
   homepage 'https://adoptopenjdk.net/'
 
   postflight do
     system_command '/bin/mv',
                    args: [
-                           '-f', '--', "#{staged_path}/jdk-#{version.before_comma}+#{version.after_comma}-jre",
+                           '-f', '--', "#{staged_path}/jdk-#{version.before_comma}+#{version.after_colon}-jre",
                            "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jre"
                          ],
                    sudo: true
 
     system_command '/bin/mkdir',
-                   args: ['-p', '--', "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jre/Contents/Home/bundle/Libraries"],
+                   args: [
+                           '-p', '--', "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jre/Contents/Home/bundle/Libraries"
+                         ],
                    sudo: true
 
     system_command '/bin/ln',
@@ -30,7 +32,7 @@ cask 'adoptopenjdk11-jre' do
 
     system_command '/usr/libexec/PlistBuddy',
                    args: [
-                           '-c', "Set :CFBundleGetInfoString AdoptOpenJDK (JRE) #{version.before_comma}+#{version.after_comma}",
+                           '-c', "Set :CFBundleGetInfoString AdoptOpenJDK (JRE) #{version.before_comma}.#{version.after_comma.before_colon}+#{version.after_colon}",
                            "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jre/Contents/Info.plist"
                          ],
                    sudo: true
@@ -51,7 +53,7 @@ cask 'adoptopenjdk11-jre' do
 
     system_command '/usr/libexec/PlistBuddy',
                    args: [
-                           '-c', "Set :JavaVM:JVMPlatformVersion #{version.before_comma}.#{version.after_comma}",
+                           '-c', "Set :JavaVM:JVMPlatformVersion #{version.before_comma}.#{version.after_comma.before_colon}+#{version.after_colon}",
                            "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jre/Contents/Info.plist"
                          ],
                    sudo: true

--- a/Casks/adoptopenjdk11-openj9.rb
+++ b/Casks/adoptopenjdk11-openj9.rb
@@ -1,23 +1,25 @@
 cask 'adoptopenjdk11-openj9' do
-  version '11.0.2,9'
-  sha256 '759c857b6fef2c44baadaa4245182e15c9ad1834cb0361358b13ac1f8fcb2692'
+  version '11,0.2:9'
+  sha256 '0589fea4f9012299267dd3c533417a37540a3db61ae86f411bda67195b3636f4'
 
   # github.com/AdoptOpenJDK was verified as official when first introduced to the cask
-  url "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-#{version.before_comma}%2B#{version.after_comma}_openj9-0.12.1/OpenJDK11U-jdk_x64_mac_openj9_#{version.before_comma}_#{version.after_comma}_openj9-0.12.1_openj9-0.12.1.tar.gz"
+  url "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-#{version.before_comma}.#{version.after_comma.before_colon}%2B#{version.after_colon}/OpenJDK11U-jdk_x64_mac_openj9_#{version.before_comma}.#{version.after_comma.before_colon}_#{version.after_colon}_openj9-0.12.0.tar.gz"
   appcast 'https://github.com/adoptopenjdk/openjdk11-binaries/releases.atom'
-  name 'AdoptOpenJDK'
+  name 'AdoptOpenJDK 11 (OpenJ9)'
   homepage 'https://adoptopenjdk.net/'
 
   postflight do
     system_command '/bin/mv',
                    args: [
-                           '-f', '--', "#{staged_path}/jdk-#{version.before_comma}+#{version.after_comma}_openj9-0.12.1",
+                           '-f', '--', "#{staged_path}/jdk-#{version.before_comma}+#{version.after_colon}_openj9-0.12.1",
                            "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}-openj9.jdk"
                          ],
                    sudo: true
 
     system_command '/bin/mkdir',
-                   args: ['-p', '--', "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}-openj9.jdk/Contents/Home/bundle/Libraries"],
+                   args: [
+                           '-p', '--', "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}-openj9.jdk/Contents/Home/bundle/Libraries"
+                         ],
                    sudo: true
 
     system_command '/bin/ln',
@@ -30,7 +32,7 @@ cask 'adoptopenjdk11-openj9' do
 
     system_command '/usr/libexec/PlistBuddy',
                    args: [
-                           '-c', "Set :CFBundleGetInfoString AdoptOpenJDK (OpenJ9) #{version.before_comma}+#{version.after_comma}",
+                           '-c', "Set :CFBundleGetInfoString AdoptOpenJDK (OpenJ9) #{version.before_comma}.#{version.after_comma.before_colon}+#{version.after_colon}",
                            "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}-openj9.jdk/Contents/Info.plist"
                          ],
                    sudo: true
@@ -51,7 +53,7 @@ cask 'adoptopenjdk11-openj9' do
 
     system_command '/usr/libexec/PlistBuddy',
                    args: [
-                           '-c', "Set :JavaVM:JVMPlatformVersion #{version.before_comma}.#{version.after_comma}",
+                           '-c', "Set :JavaVM:JVMPlatformVersion #{version.before_comma}.#{version.after_comma.before_colon}+#{version.after_colon}",
                            "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}-openj9.jdk/Contents/Info.plist"
                          ],
                    sudo: true
@@ -59,6 +61,20 @@ cask 'adoptopenjdk11-openj9' do
     system_command '/usr/libexec/PlistBuddy',
                    args: [
                            '-c', 'Set :JavaVM:JVMVendor AdoptOpenJDK',
+                           "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}-openj9.jdk/Contents/Info.plist"
+                         ],
+                   sudo: true
+
+    system_command '/usr/libexec/PlistBuddy',
+                   args: [
+                           '-c', 'Add :JavaVM:JVMCapabilities array',
+                           "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}-openj9.jdk/Contents/Info.plist"
+                         ],
+                   sudo: true
+
+    system_command '/usr/libexec/PlistBuddy',
+                   args: [
+                           '-c', 'Add :JavaVM:JVMCapabilities:0 string CommandLine',
                            "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}-openj9.jdk/Contents/Info.plist"
                          ],
                    sudo: true

--- a/Casks/adoptopenjdk11.rb
+++ b/Casks/adoptopenjdk11.rb
@@ -1,23 +1,25 @@
 cask 'adoptopenjdk11' do
-  version '11.0.2,9'
+  version '11,0.2:9'
   sha256 'fffd4ed283e5cd443760a8ec8af215c8ca4d33ec5050c24c1277ba64b5b5e81a'
 
   # github.com/AdoptOpenJDK was verified as official when first introduced to the cask
-  url "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-#{version.before_comma}%2B#{version.after_comma}/OpenJDK11U-jdk_x64_mac_hotspot_#{version.before_comma}_#{version.after_comma}.tar.gz"
+  url "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-#{version.before_comma}.#{version.after_comma.before_colon}%2B#{version.after_colon}/OpenJDK11U-jdk_x64_mac_hotspot_#{version.before_comma}.#{version.after_comma.before_colon}_#{version.after_colon}.tar.gz"
   appcast 'https://github.com/adoptopenjdk/openjdk11-binaries/releases.atom'
-  name 'AdoptOpenJDK'
+  name 'AdoptOpenJDK 11'
   homepage 'https://adoptopenjdk.net/'
 
   postflight do
     system_command '/bin/mv',
                    args: [
-                           '-f', '--', "#{staged_path}/jdk-#{version.before_comma}+#{version.after_comma}",
+                           '-f', '--', "#{staged_path}/jdk-#{version.before_comma}+#{version.after_colon}",
                            "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jdk"
                          ],
                    sudo: true
 
     system_command '/bin/mkdir',
-                   args: ['-p', '--', "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jdk/Contents/Home/bundle/Libraries"],
+                   args: [
+                           '-p', '--', "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jdk/Contents/Home/bundle/Libraries"
+                         ],
                    sudo: true
 
     system_command '/bin/ln',
@@ -30,7 +32,7 @@ cask 'adoptopenjdk11' do
 
     system_command '/usr/libexec/PlistBuddy',
                    args: [
-                           '-c', "Set :CFBundleGetInfoString AdoptOpenJDK #{version.before_comma}+#{version.after_comma}",
+                           '-c', "Set :CFBundleGetInfoString AdoptOpenJDK #{version.before_comma}.#{version.after_comma.before_colon}+#{version.after_colon}",
                            "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jdk/Contents/Info.plist"
                          ],
                    sudo: true
@@ -51,7 +53,7 @@ cask 'adoptopenjdk11' do
 
     system_command '/usr/libexec/PlistBuddy',
                    args: [
-                           '-c', "Set :JavaVM:JVMPlatformVersion #{version.before_comma}.#{version.after_comma}",
+                           '-c', "Set :JavaVM:JVMPlatformVersion #{version.before_comma}.#{version.after_comma.before_colon}+#{version.after_colon}",
                            "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jdk/Contents/Info.plist"
                          ],
                    sudo: true
@@ -59,6 +61,20 @@ cask 'adoptopenjdk11' do
     system_command '/usr/libexec/PlistBuddy',
                    args: [
                            '-c', 'Set :JavaVM:JVMVendor AdoptOpenJDK',
+                           "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jdk/Contents/Info.plist"
+                         ],
+                   sudo: true
+
+    system_command '/usr/libexec/PlistBuddy',
+                   args: [
+                           '-c', 'Add :JavaVM:JVMCapabilities array',
+                           "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jdk/Contents/Info.plist"
+                         ],
+                   sudo: true
+
+    system_command '/usr/libexec/PlistBuddy',
+                   args: [
+                           '-c', 'Add :JavaVM:JVMCapabilities:0 string CommandLine',
                            "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jdk/Contents/Info.plist"
                          ],
                    sudo: true


### PR DESCRIPTION
This pull request fixes #77 that I reported and also makes formatting consistent and adds missing JVMCapabilities to casks adoptopenjdk11, adoptopenjdk11-openj9, adoptopenjdk11-jre where necessary.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.