### PR TITLE
Update adoptopenjdk11 11.0.2:9

### DIFF
--- a/Casks/adoptopenjdk11.rb
+++ b/Casks/adoptopenjdk11.rb
@@ -11,7 +11,7 @@ cask 'adoptopenjdk11' do
   postflight do
     system_command '/bin/mv',
                    args: [
-                           '-f', '--', "#{staged_path}/jdk-#{version.before_comma}+#{version.after_colon}",
+                           '-f', '--', "#{staged_path}/jdk-#{version.before_comma}.#{version.after_comma.before_colon}+#{version.after_colon}",
                            "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jdk"
                          ],
                    sudo: true
@@ -53,7 +53,7 @@ cask 'adoptopenjdk11' do
 
     system_command '/usr/libexec/PlistBuddy',
                    args: [
-                           '-c', "Set :JavaVM:JVMPlatformVersion #{version.before_comma}.#{version.after_comma.before_colon}+#{version.after_colon}",
+                           '-c', "Set :JavaVM:JVMPlatformVersion #{version.before_comma}.#{version.after_comma.before_colon}",
                            "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jdk/Contents/Info.plist"
                          ],
                    sudo: true
@@ -61,20 +61,6 @@ cask 'adoptopenjdk11' do
     system_command '/usr/libexec/PlistBuddy',
                    args: [
                            '-c', 'Set :JavaVM:JVMVendor AdoptOpenJDK',
-                           "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jdk/Contents/Info.plist"
-                         ],
-                   sudo: true
-
-    system_command '/usr/libexec/PlistBuddy',
-                   args: [
-                           '-c', 'Add :JavaVM:JVMCapabilities array',
-                           "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jdk/Contents/Info.plist"
-                         ],
-                   sudo: true
-
-    system_command '/usr/libexec/PlistBuddy',
-                   args: [
-                           '-c', 'Add :JavaVM:JVMCapabilities:0 string CommandLine',
                            "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jdk/Contents/Info.plist"
                          ],
                    sudo: true

--- a/Casks/adoptopenjdk11.rb
+++ b/Casks/adoptopenjdk11.rb
@@ -1,23 +1,25 @@
 cask 'adoptopenjdk11' do
-  version '11.0.2,9'
+  version '11,0.2:9'
   sha256 'fffd4ed283e5cd443760a8ec8af215c8ca4d33ec5050c24c1277ba64b5b5e81a'
 
   # github.com/AdoptOpenJDK was verified as official when first introduced to the cask
-  url "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-#{version.before_comma}%2B#{version.after_comma}/OpenJDK11U-jdk_x64_mac_hotspot_#{version.before_comma}_#{version.after_comma}.tar.gz"
+  url "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-#{version.before_comma}.#{version.after_comma.before_colon}%2B#{version.after_colon}/OpenJDK11U-jdk_x64_mac_hotspot_#{version.before_comma}.#{version.after_comma.before_colon}_#{version.after_colon}.tar.gz"
   appcast 'https://github.com/adoptopenjdk/openjdk11-binaries/releases.atom'
-  name 'AdoptOpenJDK'
+  name 'AdoptOpenJDK 11'
   homepage 'https://adoptopenjdk.net/'
 
   postflight do
     system_command '/bin/mv',
                    args: [
-                           '-f', '--', "#{staged_path}/jdk-#{version.before_comma}+#{version.after_comma}",
+                           '-f', '--', "#{staged_path}/jdk-#{version.before_comma}+#{version.after_colon}",
                            "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jdk"
                          ],
                    sudo: true
 
     system_command '/bin/mkdir',
-                   args: ['-p', '--', "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jdk/Contents/Home/bundle/Libraries"],
+                   args: [
+                           '-p', '--', "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jdk/Contents/Home/bundle/Libraries"
+                         ],
                    sudo: true
 
     system_command '/bin/ln',
@@ -30,7 +32,7 @@ cask 'adoptopenjdk11' do
 
     system_command '/usr/libexec/PlistBuddy',
                    args: [
-                           '-c', "Set :CFBundleGetInfoString AdoptOpenJDK #{version.before_comma}+#{version.after_comma}",
+                           '-c', "Set :CFBundleGetInfoString AdoptOpenJDK #{version.before_comma}.#{version.after_comma.before_colon}+#{version.after_colon}",
                            "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jdk/Contents/Info.plist"
                          ],
                    sudo: true
@@ -51,7 +53,7 @@ cask 'adoptopenjdk11' do
 
     system_command '/usr/libexec/PlistBuddy',
                    args: [
-                           '-c', "Set :JavaVM:JVMPlatformVersion #{version.before_comma}.#{version.after_comma}",
+                           '-c', "Set :JavaVM:JVMPlatformVersion #{version.before_comma}.#{version.after_comma.before_colon}+#{version.after_colon}",
                            "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jdk/Contents/Info.plist"
                          ],
                    sudo: true
@@ -59,6 +61,20 @@ cask 'adoptopenjdk11' do
     system_command '/usr/libexec/PlistBuddy',
                    args: [
                            '-c', 'Set :JavaVM:JVMVendor AdoptOpenJDK',
+                           "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jdk/Contents/Info.plist"
+                         ],
+                   sudo: true
+
+    system_command '/usr/libexec/PlistBuddy',
+                   args: [
+                           '-c', 'Add :JavaVM:JVMCapabilities array',
+                           "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jdk/Contents/Info.plist"
+                         ],
+                   sudo: true
+
+    system_command '/usr/libexec/PlistBuddy',
+                   args: [
+                           '-c', 'Add :JavaVM:JVMCapabilities:0 string CommandLine',
                            "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jdk/Contents/Info.plist"
                          ],
                    sudo: true


### PR DESCRIPTION
This should fix #77 for the cask adoptopenjdk11 11.0.2:9

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.