### PR TITLE
 Open Update adoptopenjdk11-jre 11.0.2:9

### DIFF
--- a/Casks/adoptopenjdk11-jre.rb
+++ b/Casks/adoptopenjdk11-jre.rb
@@ -11,7 +11,7 @@ cask 'adoptopenjdk11-jre' do
   postflight do
     system_command '/bin/mv',
                    args: [
-                           '-f', '--', "#{staged_path}/jdk-#{version.before_comma}+#{version.after_colon}-jre",
+                           '-f', '--', "#{staged_path}/jdk-#{version.before_comma}.#{version.after_comma.before_colon}+#{version.after_colon}-jre",
                            "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jre"
                          ],
                    sudo: true
@@ -53,7 +53,7 @@ cask 'adoptopenjdk11-jre' do
 
     system_command '/usr/libexec/PlistBuddy',
                    args: [
-                           '-c', "Set :JavaVM:JVMPlatformVersion #{version.before_comma}.#{version.after_comma.before_colon}+#{version.after_colon}",
+                           '-c', "Set :JavaVM:JVMPlatformVersion #{version.before_comma}.#{version.after_comma.before_colon}",
                            "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jre/Contents/Info.plist"
                          ],
                    sudo: true

--- a/Casks/adoptopenjdk11-jre.rb
+++ b/Casks/adoptopenjdk11-jre.rb
@@ -1,23 +1,25 @@
 cask 'adoptopenjdk11-jre' do
-  version '11.0.2,9'
+  version '11,0.2:9'
   sha256 '7e70784f7833751b63cee9e197230877a4059b178a24858261f834ea39b29fd5'
 
   # github.com/AdoptOpenJDK was verified as official when first introduced to the cask
-  url "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-#{version.before_comma}%2B#{version.after_comma}/OpenJDK11U-jre_x64_mac_hotspot_#{version.before_comma}_#{version.after_comma}.tar.gz"
+  url "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-#{version.before_comma}.#{version.after_comma.before_colon}%2B#{version.after_colon}/OpenJDK11U-jre_x64_mac_hotspot_#{version.before_comma}.#{version.after_comma.before_colon}_#{version.after_colon}.tar.gz"
   appcast 'https://github.com/adoptopenjdk/openjdk11-binaries/releases.atom'
-  name 'AdoptOpenJDK'
+  name 'AdoptOpenJDK 11 (JRE)'
   homepage 'https://adoptopenjdk.net/'
 
   postflight do
     system_command '/bin/mv',
                    args: [
-                           '-f', '--', "#{staged_path}/jdk-#{version.before_comma}+#{version.after_comma}-jre",
+                           '-f', '--', "#{staged_path}/jdk-#{version.before_comma}+#{version.after_colon}-jre",
                            "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jre"
                          ],
                    sudo: true
 
     system_command '/bin/mkdir',
-                   args: ['-p', '--', "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jre/Contents/Home/bundle/Libraries"],
+                   args: [
+                           '-p', '--', "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jre/Contents/Home/bundle/Libraries"
+                         ],
                    sudo: true
 
     system_command '/bin/ln',
@@ -30,7 +32,7 @@ cask 'adoptopenjdk11-jre' do
 
     system_command '/usr/libexec/PlistBuddy',
                    args: [
-                           '-c', "Set :CFBundleGetInfoString AdoptOpenJDK (JRE) #{version.before_comma}+#{version.after_comma}",
+                           '-c', "Set :CFBundleGetInfoString AdoptOpenJDK (JRE) #{version.before_comma}.#{version.after_comma.before_colon}+#{version.after_colon}",
                            "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jre/Contents/Info.plist"
                          ],
                    sudo: true
@@ -51,7 +53,7 @@ cask 'adoptopenjdk11-jre' do
 
     system_command '/usr/libexec/PlistBuddy',
                    args: [
-                           '-c', "Set :JavaVM:JVMPlatformVersion #{version.before_comma}.#{version.after_comma}",
+                           '-c', "Set :JavaVM:JVMPlatformVersion #{version.before_comma}.#{version.after_comma.before_colon}+#{version.after_colon}",
                            "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jre/Contents/Info.plist"
                          ],
                    sudo: true


### PR DESCRIPTION
This should fix #77 for the cask adoptopenjdk11-jre 11.0.2:9

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.