### PR TITLE
Open Update adoptopenjdk11-openj9 11.0.2:9

### DIFF
--- a/Casks/adoptopenjdk11-openj9.rb
+++ b/Casks/adoptopenjdk11-openj9.rb
@@ -11,7 +11,7 @@ cask 'adoptopenjdk11-openj9' do
   postflight do
     system_command '/bin/mv',
                    args: [
-                           '-f', '--', "#{staged_path}/jdk-#{version.before_comma}+#{version.after_colon}_openj9-0.12.1",
+                           '-f', '--', "#{staged_path}/jdk-#{version.before_comma}.#{version.after_comma.before_colon}+#{version.after_colon}",
                            "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}-openj9.jdk"
                          ],
                    sudo: true
@@ -53,7 +53,7 @@ cask 'adoptopenjdk11-openj9' do
 
     system_command '/usr/libexec/PlistBuddy',
                    args: [
-                           '-c', "Set :JavaVM:JVMPlatformVersion #{version.before_comma}.#{version.after_comma.before_colon}+#{version.after_colon}",
+                           '-c', "Set :JavaVM:JVMPlatformVersion #{version.before_comma}.#{version.after_comma.before_colon}",
                            "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}-openj9.jdk/Contents/Info.plist"
                          ],
                    sudo: true
@@ -61,20 +61,6 @@ cask 'adoptopenjdk11-openj9' do
     system_command '/usr/libexec/PlistBuddy',
                    args: [
                            '-c', 'Set :JavaVM:JVMVendor AdoptOpenJDK',
-                           "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}-openj9.jdk/Contents/Info.plist"
-                         ],
-                   sudo: true
-
-    system_command '/usr/libexec/PlistBuddy',
-                   args: [
-                           '-c', 'Add :JavaVM:JVMCapabilities array',
-                           "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}-openj9.jdk/Contents/Info.plist"
-                         ],
-                   sudo: true
-
-    system_command '/usr/libexec/PlistBuddy',
-                   args: [
-                           '-c', 'Add :JavaVM:JVMCapabilities:0 string CommandLine',
                            "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}-openj9.jdk/Contents/Info.plist"
                          ],
                    sudo: true

--- a/Casks/adoptopenjdk11-openj9.rb
+++ b/Casks/adoptopenjdk11-openj9.rb
@@ -1,23 +1,25 @@
 cask 'adoptopenjdk11-openj9' do
-  version '11.0.2,9'
-  sha256 '759c857b6fef2c44baadaa4245182e15c9ad1834cb0361358b13ac1f8fcb2692'
+  version '11,0.2:9'
+  sha256 '0589fea4f9012299267dd3c533417a37540a3db61ae86f411bda67195b3636f4'
 
   # github.com/AdoptOpenJDK was verified as official when first introduced to the cask
-  url "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-#{version.before_comma}%2B#{version.after_comma}_openj9-0.12.1/OpenJDK11U-jdk_x64_mac_openj9_#{version.before_comma}_#{version.after_comma}_openj9-0.12.1_openj9-0.12.1.tar.gz"
+  url "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-#{version.before_comma}.#{version.after_comma.before_colon}%2B#{version.after_colon}/OpenJDK11U-jdk_x64_mac_openj9_#{version.before_comma}.#{version.after_comma.before_colon}_#{version.after_colon}_openj9-0.12.0.tar.gz"
   appcast 'https://github.com/adoptopenjdk/openjdk11-binaries/releases.atom'
-  name 'AdoptOpenJDK'
+  name 'AdoptOpenJDK 11 (OpenJ9)'
   homepage 'https://adoptopenjdk.net/'
 
   postflight do
     system_command '/bin/mv',
                    args: [
-                           '-f', '--', "#{staged_path}/jdk-#{version.before_comma}+#{version.after_comma}_openj9-0.12.1",
+                           '-f', '--', "#{staged_path}/jdk-#{version.before_comma}+#{version.after_colon}_openj9-0.12.1",
                            "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}-openj9.jdk"
                          ],
                    sudo: true
 
     system_command '/bin/mkdir',
-                   args: ['-p', '--', "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}-openj9.jdk/Contents/Home/bundle/Libraries"],
+                   args: [
+                           '-p', '--', "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}-openj9.jdk/Contents/Home/bundle/Libraries"
+                         ],
                    sudo: true
 
     system_command '/bin/ln',
@@ -30,7 +32,7 @@ cask 'adoptopenjdk11-openj9' do
 
     system_command '/usr/libexec/PlistBuddy',
                    args: [
-                           '-c', "Set :CFBundleGetInfoString AdoptOpenJDK (OpenJ9) #{version.before_comma}+#{version.after_comma}",
+                           '-c', "Set :CFBundleGetInfoString AdoptOpenJDK (OpenJ9) #{version.before_comma}.#{version.after_comma.before_colon}+#{version.after_colon}",
                            "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}-openj9.jdk/Contents/Info.plist"
                          ],
                    sudo: true
@@ -51,7 +53,7 @@ cask 'adoptopenjdk11-openj9' do
 
     system_command '/usr/libexec/PlistBuddy',
                    args: [
-                           '-c', "Set :JavaVM:JVMPlatformVersion #{version.before_comma}.#{version.after_comma}",
+                           '-c', "Set :JavaVM:JVMPlatformVersion #{version.before_comma}.#{version.after_comma.before_colon}+#{version.after_colon}",
                            "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}-openj9.jdk/Contents/Info.plist"
                          ],
                    sudo: true
@@ -59,6 +61,20 @@ cask 'adoptopenjdk11-openj9' do
     system_command '/usr/libexec/PlistBuddy',
                    args: [
                            '-c', 'Set :JavaVM:JVMVendor AdoptOpenJDK',
+                           "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}-openj9.jdk/Contents/Info.plist"
+                         ],
+                   sudo: true
+
+    system_command '/usr/libexec/PlistBuddy',
+                   args: [
+                           '-c', 'Add :JavaVM:JVMCapabilities array',
+                           "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}-openj9.jdk/Contents/Info.plist"
+                         ],
+                   sudo: true
+
+    system_command '/usr/libexec/PlistBuddy',
+                   args: [
+                           '-c', 'Add :JavaVM:JVMCapabilities:0 string CommandLine',
                            "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}-openj9.jdk/Contents/Info.plist"
                          ],
                    sudo: true


### PR DESCRIPTION
This should fix #77 for the cask adoptopenjdk11-openj9 11.0.2:9

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.