### PR TITLE
Adds adoptopenjdk11-open9-jre for #24

### DIFF
--- a/Casks/adoptopenjdk11-openj9-jre.rb
+++ b/Casks/adoptopenjdk11-openj9-jre.rb
@@ -1,0 +1,84 @@
+cask 'adoptopenjdk11-openj9-jre' do
+  version '11,0.2:9'
+  sha256 '40d70bf570b2098b381b77ae62dfddfb8cf6fc500ed539d82b78405593a9c9e5'
+
+  # github.com/AdoptOpenJDK was verified as official when first introduced to the cask
+  url "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-#{version.before_comma}.#{version.after_comma.before_colon}%2B#{version.after_colon}/OpenJDK11U-jre_x64_mac_openj9_#{version.before_comma}.#{version.after_comma.before_colon}_#{version.after_colon}_openj9-0.12.0.tar.gz"
+  appcast 'https://github.com/adoptopenjdk/openjdk11-binaries/releases.atom'
+  name 'AdoptOpenJDK 11 (OpenJ9 JRE)'
+  homepage 'https://adoptopenjdk.net/'
+
+  postflight do
+    system_command '/bin/mv',
+                   args: [
+                           '-f', '--', "#{staged_path}/jdk-#{version.before_comma}.#{version.after_comma.before_colon}+#{version.after_colon}-jre",
+                           "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}-openj9.jre"
+                         ],
+                   sudo: true
+
+    system_command '/bin/mkdir',
+                   args: [
+                           '-p', '--', "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}-openj9.jre/Contents/Home/bundle/Libraries"
+                         ],
+                   sudo: true
+
+    system_command '/bin/ln',
+                   args: [
+                           '-nsf', '--',
+                           "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}-openj9.jre/Contents/Home/lib/server/libjvm.dylib",
+                           "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}-openj9.jre/Contents/Home/bundle/Libraries/libserver.dylib"
+                         ],
+                   sudo: true
+
+    system_command '/usr/libexec/PlistBuddy',
+                   args: [
+                           '-c', "Set :CFBundleGetInfoString AdoptOpenJDK (OpenJ9 JRE) #{version.before_comma}.#{version.after_comma.before_colon}+#{version.after_colon}",
+                           "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}-openj9.jre/Contents/Info.plist"
+                         ],
+                   sudo: true
+
+    system_command '/usr/libexec/PlistBuddy',
+                   args: [
+                           '-c', "Set :CFBundleIdentifier net.adoptopenjdk.#{version.before_comma}-openj9.jre",
+                           "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}-openj9.jre/Contents/Info.plist"
+                         ],
+                   sudo: true
+
+    system_command '/usr/libexec/PlistBuddy',
+                   args: [
+                           '-c', "Set :CFBundleName AdoptOpenJDK (OpenJ9 JRE) #{version.before_comma}",
+                           "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}-openj9.jre/Contents/Info.plist"
+                         ],
+                   sudo: true
+
+    system_command '/usr/libexec/PlistBuddy',
+                   args: [
+                           '-c', "Set :JavaVM:JVMPlatformVersion #{version.before_comma}.#{version.after_comma.before_colon}+#{version.after_colon}",
+                           "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}-openj9.jre/Contents/Info.plist"
+                         ],
+                   sudo: true
+
+    system_command '/usr/libexec/PlistBuddy',
+                   args: [
+                           '-c', 'Set :JavaVM:JVMVendor AdoptOpenJDK',
+                           "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}-openj9.jre/Contents/Info.plist"
+                         ],
+                   sudo: true
+
+    system_command '/usr/libexec/PlistBuddy',
+                   args: [
+                           '-c', 'Add :JavaVM:JVMCapabilities array',
+                           "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}-openj9.jre/Contents/Info.plist"
+                         ],
+                   sudo: true
+
+    system_command '/usr/libexec/PlistBuddy',
+                   args: [
+                           '-c', 'Add :JavaVM:JVMCapabilities:0 string CommandLine',
+                           "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}-openj9.jre/Contents/Info.plist"
+                         ],
+                   sudo: true
+  end
+
+  uninstall delete: "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}-openj9.jre"
+end

--- a/README.md
+++ b/README.md
@@ -19,4 +19,4 @@ brew cask install <version>
 | OpenJDK9 with Hotspot JVM | `adoptopenjdk9` | n/a |
 | OpenJDK10 with Hotspot JVM | `adoptopenjdk10` | n/a |
 | OpenJDK11 with Hotspot JVM | `adoptopenjdk11` | `adoptopenjdk11-jre` |
-| OpenJDK11 with OpenJ9 JVM | `adoptopenjdk11-openj9` | n/a |
+| OpenJDK11 with OpenJ9 JVM | `adoptopenjdk11-openj9` | `adoptopenjdk11-openj9-jre` |


### PR DESCRIPTION
This should add adoptopenjdk11-open9-jre according to #24.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [x] Named the cask in a similar way to the existing casks.
- [x] Added new cask to the README.md
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
