### PR TITLE
Adds adoptopenjdk9-jre cask

### DIFF
--- a/Casks/adoptopenjdk9-jre.rb
+++ b/Casks/adoptopenjdk9-jre.rb
@@ -1,0 +1,84 @@
+cask 'adoptopenjdk9-jre' do
+  version '9,181'
+  sha256 'f92931d258486d77dd986fa0fd2574075569e2f76624822d50bfae01ed72e7e7'
+
+  # github.com/AdoptOpenJDK was verified as official when first introduced to the cask
+  url "https://github.com/AdoptOpenJDK/openjdk#{version.before_comma}-binaries/releases/download/jdk-#{version.before_comma}%2B#{version.after_comma}/OpenJDK#{version.before_comma}U-jre_x64_mac_hotspot_#{version.before_comma}_#{version.after_comma}.tar.gz"
+  appcast "https://github.com/adoptopenjdk/openjdk#{version.before_comma}-binaries/releases.atom"
+  name 'AdoptOpenJDK 9 (JRE)'
+  homepage 'https://adoptopenjdk.net/'
+
+  postflight do
+    system_command '/bin/mv',
+                   args: [
+                           '-f', '--', "#{staged_path}/jdk-#{version.before_comma}+#{version.after_comma}-jre",
+                           "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jre"
+                         ],
+                   sudo: true
+
+    system_command '/bin/mkdir',
+                   args: [
+                           '-p', '--', "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jre/Contents/Home/bundle/Libraries"
+                         ],
+                   sudo: true
+
+    system_command '/bin/ln',
+                   args: [
+                           '-nsf', '--',
+                           "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jre/Contents/Home/lib/server/libjvm.dylib",
+                           "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jre/Contents/Home/bundle/Libraries/libserver.dylib"
+                         ],
+                   sudo: true
+
+    system_command '/usr/libexec/PlistBuddy',
+                   args: [
+                           '-c', "Set :CFBundleGetInfoString AdoptOpenJDK (JRE) #{version.before_comma}+#{version.after_comma}",
+                           "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jre/Contents/Info.plist"
+                         ],
+                   sudo: true
+
+    system_command '/usr/libexec/PlistBuddy',
+                   args: [
+                           '-c', "Set :CFBundleIdentifier net.adoptopenjdk.#{version.before_comma}.jre",
+                           "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jre/Contents/Info.plist"
+                         ],
+                   sudo: true
+
+    system_command '/usr/libexec/PlistBuddy',
+                   args: [
+                           '-c', "Set :CFBundleName AdoptOpenJDK (JRE) #{version.before_comma}",
+                           "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jre/Contents/Info.plist"
+                         ],
+                   sudo: true
+
+    system_command '/usr/libexec/PlistBuddy',
+                   args: [
+                           '-c', "Set :JavaVM:JVMPlatformVersion #{version.before_comma}.#{version.after_comma}",
+                           "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jre/Contents/Info.plist"
+                         ],
+                   sudo: true
+
+    system_command '/usr/libexec/PlistBuddy',
+                   args: [
+                           '-c', 'Set :JavaVM:JVMVendor AdoptOpenJDK',
+                           "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jre/Contents/Info.plist"
+                         ],
+                   sudo: true
+
+    system_command '/usr/libexec/PlistBuddy',
+                   args: [
+                           '-c', 'Add :JavaVM:JVMCapabilities array',
+                           "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jre/Contents/Info.plist"
+                         ],
+                   sudo: true
+
+    system_command '/usr/libexec/PlistBuddy',
+                   args: [
+                           '-c', 'Add :JavaVM:JVMCapabilities:0 string CommandLine',
+                           "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jre/Contents/Info.plist"
+                         ],
+                   sudo: true
+  end
+
+  uninstall delete: "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jre"
+end

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ brew cask install <version>
 |--|--|--|
 | OpenJDK8 with Hotspot JVM | `adoptopenjdk8` | `adoptopenjdk8-jre` |
 | OpenJDK8 with OpenJ9 JVM | `adoptopenjdk8-openj9` | `adoptopenjdk8-openj9-jre` |
-| OpenJDK9 with Hotspot JVM | `adoptopenjdk9` | n/a |
+| OpenJDK9 with Hotspot JVM | `adoptopenjdk9` | `adoptopenjdk9-jre` |
 | OpenJDK10 with Hotspot JVM | `adoptopenjdk10` | n/a |
 | OpenJDK11 with Hotspot JVM | `adoptopenjdk11` | `adoptopenjdk11-jre` |
 | OpenJDK11 with OpenJ9 JVM | `adoptopenjdk11-openj9` | `adoptopenjdk11-openj9-jre` |


### PR DESCRIPTION
In reference to #24 I created a jkd9-jre cask that should fill in that gap.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [x] Named the cask in a similar way to the existing casks.
- [x] Added new cask to the README.md
- [x] `brew cask install {{cask_file}}` worked successfully.
- [X] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
