### PR TITLE
update adoptopenjdk8 to 8u212-b03

### DIFF
--- a/Casks/adoptopenjdk8.rb
+++ b/Casks/adoptopenjdk8.rb
@@ -1,14 +1,14 @@
 cask 'adoptopenjdk8' do
-  version '8,202:b08'
-  sha256 '0149a5c0f35e31d8faab3e160f800c4537bcc6f9290f986fff47e61229c2e3bf'
+  version '8,212:b03'
+  sha256 'd0e4265b151d87235a74e354725fdc218d60abb06c253af0993fd2fcf4c3a355'
 
   # github.com/AdoptOpenJDK was verified as official when first introduced to the cask
-  url "https://github.com/AdoptOpenJDK/openjdk#{version.before_comma}-binaries/releases/download/jdk#{version.before_comma}u#{version.after_comma.before_colon}-#{version.after_colon}/OpenJDK#{version.before_comma}U-jdk_x64_mac_hotspot_#{version.before_comma}u#{version.after_comma.before_colon}#{version.after_colon}.pkg"
+  url 'https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u212-b03/OpenJDK8U-jdk_x64_mac_hotspot_8u212b03.pkg'
   appcast "https://github.com/adoptopenjdk/openjdk#{version.before_comma}-binaries/releases.atom"
   name 'AdoptOpenJDK 8'
   homepage 'https://adoptopenjdk.net/'
 
-  pkg "OpenJDK#{version.before_comma}U-jdk_x64_mac_hotspot_#{version.before_comma}u#{version.after_comma.before_colon}#{version.after_colon}.pkg"
+  pkg 'OpenJDK8U-jdk_x64_mac_hotspot_8u212b03.pkg'
 
   uninstall pkgutil: [
                        "net.adoptopenjdk.#{version.before_comma}.jdk",


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

