### PR TITLE
fix appcast issues

### DIFF
--- a/Casks/adoptopenjdk11-jre.rb
+++ b/Casks/adoptopenjdk11-jre.rb
@@ -1,10 +1,10 @@
 cask 'adoptopenjdk11-jre' do
-  version '11,0.4:11'
+  version '11.0.4,11'
   sha256 '1cb3701e1c70e73b62805bcebbd4ba0c0a12a1cfa23674c12a2ad736b532f6ff'
 
   # github.com/AdoptOpenJDK was verified as official when first introduced to the cask
   url 'https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.4%2B11/OpenJDK11U-jre_x64_mac_hotspot_11.0.4_11.pkg'
-  appcast "https://github.com/adoptopenjdk/openjdk#{version.before_comma}-binaries/releases.atom"
+  appcast "https://github.com/AdoptOpenJDK/openjdk#{version.major}-binaries/releases/latest"
   name 'AdoptOpenJDK 11 (JRE)'
   homepage 'https://adoptopenjdk.net/'
 

--- a/Casks/adoptopenjdk11-openj9-jre-large.rb
+++ b/Casks/adoptopenjdk11-openj9-jre-large.rb
@@ -1,10 +1,10 @@
 cask 'adoptopenjdk11-openj9-jre-large' do
-  version '11,0.4:11'
+  version '11.0.4,11'
   sha256 'aa40cbe7a5a990a7d8919bbf1eb221c53bf3b1198d7d19e4909b02f4710d4d13'
 
   # github.com/AdoptOpenJDK was verified as official when first introduced to the cask
   url 'https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.4%2B11_openj9-0.15.1/OpenJDK11U-jre_x64_mac_openj9_macosXL_11.0.4_11_openj9-0.15.1.pkg'
-  appcast "https://github.com/adoptopenjdk/openjdk#{version.before_comma}-binaries/releases.atom"
+  appcast "https://github.com/AdoptOpenJDK/openjdk#{version.major}-binaries/releases/latest"
   name 'AdoptOpenJDK 11 (OpenJ9)'
   homepage 'https://adoptopenjdk.net/'
 

--- a/Casks/adoptopenjdk11-openj9-jre.rb
+++ b/Casks/adoptopenjdk11-openj9-jre.rb
@@ -1,10 +1,10 @@
 cask 'adoptopenjdk11-openj9-jre' do
-  version '11,0.4:11'
+  version '11.0.4,11'
   sha256 'debeeb36f739f11ee0e484be6c40eaf02989e605c02f6d16bcf47b7f813bca5a'
 
   # github.com/AdoptOpenJDK was verified as official when first introduced to the cask
   url 'https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.4%2B11_openj9-0.15.1/OpenJDK11U-jre_x64_mac_openj9_11.0.4_11_openj9-0.15.1.pkg'
-  appcast "https://github.com/adoptopenjdk/openjdk#{version.before_comma}-binaries/releases.atom"
+  appcast "https://github.com/AdoptOpenJDK/openjdk#{version.major}-binaries/releases/latest"
   name 'AdoptOpenJDK 11 (OpenJ9 JRE)'
   homepage 'https://adoptopenjdk.net/'
 

--- a/Casks/adoptopenjdk11-openj9-large.rb
+++ b/Casks/adoptopenjdk11-openj9-large.rb
@@ -1,10 +1,10 @@
 cask 'adoptopenjdk11-openj9-large' do
-  version '11,0.4:11'
+  version '11.0.4,11'
   sha256 'f8868f99a63173e21fec8f95b9d194470e3fd8b7e48be2dc2fe8d11ae3444cbb'
 
   # github.com/AdoptOpenJDK was verified as official when first introduced to the cask
   url 'https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.4%2B11_openj9-0.15.1/OpenJDK11U-jdk_x64_mac_openj9_macosXL_11.0.4_11_openj9-0.15.1.pkg'
-  appcast "https://github.com/adoptopenjdk/openjdk#{version.before_comma}-binaries/releases.atom"
+  appcast "https://github.com/AdoptOpenJDK/openjdk#{version.major}-binaries/releases/latest"
   name 'AdoptOpenJDK 11 (OpenJ9)'
   homepage 'https://adoptopenjdk.net/'
 

--- a/Casks/adoptopenjdk11-openj9.rb
+++ b/Casks/adoptopenjdk11-openj9.rb
@@ -1,10 +1,10 @@
 cask 'adoptopenjdk11-openj9' do
-  version '11,0.4:11'
+  version '11.0.4,11'
   sha256 '1d653f993a11643f2225a80174c8536c775d48cfc045e2c09ce65671440478d4'
 
   # github.com/AdoptOpenJDK was verified as official when first introduced to the cask
   url 'https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.4%2B11_openj9-0.15.1/OpenJDK11U-jdk_x64_mac_openj9_11.0.4_11_openj9-0.15.1.pkg'
-  appcast "https://github.com/adoptopenjdk/openjdk#{version.before_comma}-binaries/releases.atom"
+  appcast "https://github.com/AdoptOpenJDK/openjdk#{version.major}-binaries/releases/latest"
   name 'AdoptOpenJDK 11 (OpenJ9)'
   homepage 'https://adoptopenjdk.net/'
 

--- a/Casks/adoptopenjdk11.rb
+++ b/Casks/adoptopenjdk11.rb
@@ -1,10 +1,10 @@
 cask 'adoptopenjdk11' do
-  version '11,0.4:11'
+  version '11.0.4,11'
   sha256 '28c3e4d85ea09b8a5428ab5c5a43da25d777b256748b8c12453627ff91838c05'
 
   # github.com/AdoptOpenJDK was verified as official when first introduced to the cask
   url 'https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.4%2B11/OpenJDK11U-jdk_x64_mac_hotspot_11.0.4_11.pkg'
-  appcast "https://github.com/adoptopenjdk/openjdk#{version.before_comma}-binaries/releases.atom"
+  appcast "https://github.com/AdoptOpenJDK/openjdk#{version.major}-binaries/releases/latest"
   name 'AdoptOpenJDK 11'
   homepage 'https://adoptopenjdk.net/'
 

--- a/Casks/adoptopenjdk12-jre.rb
+++ b/Casks/adoptopenjdk12-jre.rb
@@ -1,10 +1,10 @@
 cask 'adoptopenjdk12-jre' do
-  version '12.0.2+10'
+  version '12.0.2,10'
   sha256 'ebdf14af4766b89ac16db5d00e60757bcb8659c6d3887c1cd311f7ffacc8c42f'
 
   # github.com/AdoptOpenJDK was verified as official when first introduced to the cask
   url 'https://github.com/AdoptOpenJDK/openjdk12-binaries/releases/download/jdk-12.0.2%2B10/OpenJDK12U-jre_x64_mac_hotspot_12.0.2_10.pkg'
-  appcast 'https://github.com/adoptopenjdk/openjdk12-binaries/releases.atom'
+  appcast "https://github.com/AdoptOpenJDK/openjdk#{version.major}-binaries/releases/latest"
   name 'AdoptOpenJDK 12 (JRE)'
   homepage 'https://adoptopenjdk.net/'
 

--- a/Casks/adoptopenjdk12-openj9-jre.rb
+++ b/Casks/adoptopenjdk12-openj9-jre.rb
@@ -1,10 +1,10 @@
 cask 'adoptopenjdk12-openj9-jre' do
-  version '12.0.2+10'
+  version '12.0.2,10'
   sha256 '74f960d4522300d7b274060c278b01f5d405444ed7837ca2009325988d5ff295'
 
   # github.com/AdoptOpenJDK was verified as official when first introduced to the cask
   url 'https://github.com/AdoptOpenJDK/openjdk12-binaries/releases/download/jdk-12.0.2%2B10_openj9-0.15.1/OpenJDK12U-jre_x64_mac_openj9_12.0.2_10_openj9-0.15.1.pkg'
-  appcast 'https://github.com/adoptopenjdk/openjdk12-binaries/releases.atom'
+  appcast "https://github.com/AdoptOpenJDK/openjdk#{version.major}-binaries/releases/latest"
   name 'AdoptOpenJDK 12 (OpenJ9 JRE)'
   homepage 'https://adoptopenjdk.net/'
 

--- a/Casks/adoptopenjdk12-openj9.rb
+++ b/Casks/adoptopenjdk12-openj9.rb
@@ -1,10 +1,10 @@
 cask 'adoptopenjdk12-openj9' do
-  version '12.0.2+10'
+  version '12.0.2,10'
   sha256 '71f0d8ae7bbb398efa345e807440a22add33cb131b52610050ca4d72d338a879'
 
   # github.com/AdoptOpenJDK was verified as official when first introduced to the cask
   url 'https://github.com/AdoptOpenJDK/openjdk12-binaries/releases/download/jdk-12.0.2%2B10_openj9-0.15.1/OpenJDK12U-jdk_x64_mac_openj9_12.0.2_10_openj9-0.15.1.pkg'
-  appcast 'https://github.com/adoptopenjdk/openjdk12-binaries/releases.atom'
+  appcast "https://github.com/AdoptOpenJDK/openjdk#{version.major}-binaries/releases/latest"
   name 'AdoptOpenJDK 12 (OpenJ9)'
   homepage 'https://adoptopenjdk.net/'
 

--- a/Casks/adoptopenjdk12.rb
+++ b/Casks/adoptopenjdk12.rb
@@ -1,10 +1,10 @@
 cask 'adoptopenjdk12' do
-  version '12.0.2+10'
+  version '12.0.2,10'
   sha256 '2cff36b04343762fe323f1bbbc2ca08c8116e6e8009fb166c30d57bf0bda1c82'
 
   # github.com/AdoptOpenJDK was verified as official when first introduced to the cask
   url 'https://github.com/AdoptOpenJDK/openjdk12-binaries/releases/download/jdk-12.0.2%2B10/OpenJDK12U-jdk_x64_mac_hotspot_12.0.2_10.pkg'
-  appcast 'https://github.com/adoptopenjdk/openjdk12-binaries/releases.atom'
+  appcast "https://github.com/AdoptOpenJDK/openjdk#{version.major}-binaries/releases/latest"
   name 'AdoptOpenJDK 12'
   homepage 'https://adoptopenjdk.net/'
 

--- a/Casks/adoptopenjdk8-jre.rb
+++ b/Casks/adoptopenjdk8-jre.rb
@@ -4,7 +4,7 @@ cask 'adoptopenjdk8-jre' do
 
   # github.com/AdoptOpenJDK was verified as official when first introduced to the cask
   url 'https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u222-b10/OpenJDK8U-jre_x64_mac_hotspot_8u222b10.pkg'
-  appcast "https://github.com/adoptopenjdk/openjdk#{version.before_comma}-binaries/releases.atom"
+  appcast "https://github.com/adoptopenjdk/openjdk#{version.before_comma}-binaries/releases/latest"
   name 'AdoptOpenJDK 8'
   homepage 'https://adoptopenjdk.net/'
 

--- a/Casks/adoptopenjdk8-openj9-jre-large.rb
+++ b/Casks/adoptopenjdk8-openj9-jre-large.rb
@@ -4,7 +4,7 @@ cask 'adoptopenjdk8-openj9-jre-large' do
 
   # github.com/AdoptOpenJDK was verified as official when first introduced to the cask
   url 'https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u222-b10_openj9-0.15.1/OpenJDK8U-jre_x64_mac_openj9_macosXL_8u222b10_openj9-0.15.1.pkg'
-  appcast "https://github.com/adoptopenjdk/openjdk#{version.before_comma}-binaries/releases.atom"
+  appcast "https://github.com/adoptopenjdk/openjdk#{version.before_comma}-binaries/releases/latest"
   name 'AdoptOpenJDK 8'
   homepage 'https://adoptopenjdk.net/'
 

--- a/Casks/adoptopenjdk8-openj9-jre.rb
+++ b/Casks/adoptopenjdk8-openj9-jre.rb
@@ -4,7 +4,7 @@ cask 'adoptopenjdk8-openj9-jre' do
 
   # github.com/AdoptOpenJDK was verified as official when first introduced to the cask
   url 'https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u222-b10_openj9-0.15.1/OpenJDK8U-jre_x64_mac_openj9_8u222b10_openj9-0.15.1.pkg'
-  appcast "https://github.com/adoptopenjdk/openjdk#{version.before_comma}-binaries/releases.atom"
+  appcast "https://github.com/adoptopenjdk/openjdk#{version.before_comma}-binaries/releases/latest"
   name 'AdoptOpenJDK 8'
   homepage 'https://adoptopenjdk.net/'
 

--- a/Casks/adoptopenjdk8-openj9-large.rb
+++ b/Casks/adoptopenjdk8-openj9-large.rb
@@ -4,7 +4,7 @@ cask 'adoptopenjdk8-openj9-large' do
 
   # github.com/AdoptOpenJDK was verified as official when first introduced to the cask
   url 'https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u222-b10_openj9-0.15.1/OpenJDK8U-jdk_x64_mac_openj9_macosXL_8u222b10_openj9-0.15.1.pkg'
-  appcast "https://github.com/adoptopenjdk/openjdk#{version.before_comma}-binaries/releases.atom"
+  appcast "https://github.com/adoptopenjdk/openjdk#{version.before_comma}-binaries/releases/latest"
   name 'AdoptOpenJDK 8'
   homepage 'https://adoptopenjdk.net/'
 

--- a/Casks/adoptopenjdk8-openj9.rb
+++ b/Casks/adoptopenjdk8-openj9.rb
@@ -4,7 +4,7 @@ cask 'adoptopenjdk8-openj9' do
 
   # github.com/AdoptOpenJDK was verified as official when first introduced to the cask
   url 'https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u222-b10_openj9-0.15.1/OpenJDK8U-jdk_x64_mac_openj9_8u222b10_openj9-0.15.1.pkg'
-  appcast "https://github.com/adoptopenjdk/openjdk#{version.before_comma}-binaries/releases.atom"
+  appcast "https://github.com/adoptopenjdk/openjdk#{version.before_comma}-binaries/releases/latest"
   name 'AdoptOpenJDK 8'
   homepage 'https://adoptopenjdk.net/'
 


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

The homebrew core community hit the same issue with the appcast URL. This PR switches our appcast URLs to be the same as the upstream ones: https://github.com/Homebrew/homebrew-cask/pull/66457
