### PR TITLE
update adoptopenjdk11-jre.rb to 11.0.4,11

### DIFF
--- a/Casks/adoptopenjdk11-jre.rb
+++ b/Casks/adoptopenjdk11-jre.rb
@@ -1,9 +1,9 @@
 cask 'adoptopenjdk11-jre' do
   version '11.0.4,11'
-  sha256 '689511057edac26f8b0b1fd8ef51473c01db30fd47203737940ca0581b94c003'
+  sha256 '66819d47857a460023ecdba31bac21330368f8d81706652846f79db447405814'
 
   # github.com/AdoptOpenJDK was verified as official when first introduced to the cask
-  url 'https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.4%2B11.2/OpenJDK11U-jre_x64_mac_hotspot_11.0.4_11.pkg'
+  url 'https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.4%2B11.4/OpenJDK11U-jre_x64_mac_hotspot_11.0.4_11.pkg'
   appcast "https://github.com/AdoptOpenJDK/openjdk#{version.major}-binaries/releases/latest"
   name 'AdoptOpenJDK 11 (JRE)'
   homepage 'https://adoptopenjdk.net/'


### PR DESCRIPTION
Update to 11.0.4+11.4.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.