### PR TITLE
update adoptopenjdk11-openj9-jre.rb to 11.0.4,11

### DIFF
--- a/Casks/adoptopenjdk11-openj9-jre.rb
+++ b/Casks/adoptopenjdk11-openj9-jre.rb
@@ -1,9 +1,9 @@
 cask 'adoptopenjdk11-openj9-jre' do
   version '11.0.4,11'
-  sha256 '8595fcf58f0894d105d629180656425915154dc0b3737e89fca9d8984bf6aedf'
+  sha256 'b62497189f9714016c882b627fa2bbc4be119be4406a1a463de5ab5d052b3796'
 
   # github.com/AdoptOpenJDK was verified as official when first introduced to the cask
-  url 'https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.4%2B11.2_openj9-0.15.1/OpenJDK11U-jre_x64_mac_openj9_11.0.4_11_openj9-0.15.1.pkg'
+  url 'https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.4%2B11.4_openj9-0.15.1/OpenJDK11U-jre_x64_mac_openj9_11.0.4_11_openj9-0.15.1.pkg'
   appcast "https://github.com/AdoptOpenJDK/openjdk#{version.major}-binaries/releases/latest"
   name 'AdoptOpenJDK 11 (OpenJ9 JRE)'
   homepage 'https://adoptopenjdk.net/'


### PR DESCRIPTION
Update to 11.0.4+11.4.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.