### PR TITLE
update adoptopenjdk11-openj9-large.rb to 11.0.4,11

### DIFF
--- a/Casks/adoptopenjdk11-openj9-large.rb
+++ b/Casks/adoptopenjdk11-openj9-large.rb
@@ -1,9 +1,9 @@
 cask 'adoptopenjdk11-openj9-large' do
   version '11.0.4,11'
-  sha256 '72424c40d3ace2a88116a7cc66f31c8011cf8f59e62c9cbbad8ae46c1a40ff2d'
+  sha256 '87d2f460daeff88fd9c0c896578d358f49d0c87e3238abb22b289b5df1bd00e7'
 
   # github.com/AdoptOpenJDK was verified as official when first introduced to the cask
-  url 'https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.4%2B11.2_openj9-0.15.1/OpenJDK11U-jdk_x64_mac_openj9_macosXL_11.0.4_11_openj9-0.15.1.pkg'
+  url 'https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.4%2B11.4_openj9-0.15.1/OpenJDK11U-jdk_x64_mac_openj9_macosXL_11.0.4_11_openj9-0.15.1.pkg'
   appcast "https://github.com/AdoptOpenJDK/openjdk#{version.major}-binaries/releases/latest"
   name 'AdoptOpenJDK 11 (OpenJ9) (XL)'
   homepage 'https://adoptopenjdk.net/'


### PR DESCRIPTION
Update to 11.0.4+11.4.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.