### PR TITLE
update adoptopenjdk11-openj9.rb to 11.0.4,11

### DIFF
--- a/Casks/adoptopenjdk11-openj9.rb
+++ b/Casks/adoptopenjdk11-openj9.rb
@@ -1,9 +1,9 @@
 cask 'adoptopenjdk11-openj9' do
   version '11.0.4,11'
-  sha256 'f3140b387aae1f7a08cc6b903863ba960c78473ddc98e4233b09d4dbc7e6fb6f'
+  sha256 'd912fa04c997ac3f185bf7874ee2e2ac7011e297f246dcd681797d30757748dc'
 
   # github.com/AdoptOpenJDK was verified as official when first introduced to the cask
-  url 'https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.4%2B11.2_openj9-0.15.1/OpenJDK11U-jdk_x64_mac_openj9_11.0.4_11_openj9-0.15.1.pkg'
+  url 'https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.4%2B11.4_openj9-0.15.1/OpenJDK11U-jdk_x64_mac_openj9_11.0.4_11_openj9-0.15.1.pkg'
   appcast "https://github.com/AdoptOpenJDK/openjdk#{version.major}-binaries/releases/latest"
   name 'AdoptOpenJDK 11 (OpenJ9)'
   homepage 'https://adoptopenjdk.net/'


### PR DESCRIPTION
Update to 11.0.4+11.4.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.