### PR TITLE
update adoptopenjdk11.rb to 11.0.4,11

### DIFF
--- a/Casks/adoptopenjdk11.rb
+++ b/Casks/adoptopenjdk11.rb
@@ -1,9 +1,9 @@
 cask 'adoptopenjdk11' do
   version '11.0.4,11'
-  sha256 '23b8776689cb6d2b8073f331147b2ea9a52097d28d256ae03734e1ac2c7cfa40'
+  sha256 '555fd51cb60aa37967db48ee1bd6ec184dd2c2fbf045493f16203c1ca4494359'
 
   # github.com/AdoptOpenJDK was verified as official when first introduced to the cask
-  url 'https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.4%2B11.2/OpenJDK11U-jdk_x64_mac_hotspot_11.0.4_11.pkg'
+  url 'https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.4%2B11.4/OpenJDK11U-jdk_x64_mac_hotspot_11.0.4_11.pkg'
   appcast "https://github.com/AdoptOpenJDK/openjdk#{version.major}-binaries/releases/latest"
   name 'AdoptOpenJDK 11'
   homepage 'https://adoptopenjdk.net/'


### PR DESCRIPTION
Update to 11.0.4+11.4.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.