### PR TITLE
Add fish shell support for switching between JDK version on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,16 @@ jdk() {
  }
 ```
 
+For Fish shell user, add the below function in your `~/.config/fish/functions`
+
+```fish
+function jdk
+	set java_version $argv
+	set -Ux JAVA_HOME (/usr/libexec/java_home -v $java_version)
+	java -version
+end
+```
+
  2. Source the profile and you can change the version like below:
  ```bash
   jdk 1.8


### PR DESCRIPTION
## Description
As a fish shell user, I also need to [switch between JDK version](https://github.com/AdoptOpenJDK/homebrew-openjdk/pull/314). The fish shell function syntax is different than the bash syntax. I hope by adding the fish shell snippet in the readme.md, it would help other fish shell users.


## Note
`version` variable in fish shell is a [special variables](https://fishshell.com/docs/current/#special-variables). So, I use `java_version` instead.