### PR TITLE
Update README.md for the invalid switch command

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Multiple major releases can be installed side-by-side. To get a list of availabl
 ```bash
 jdk() {
         version=$1
-        export JAVA_HOME=$(/usr/libexec/java_home -v"$version");
+        export JAVA_HOME=$(/usr/libexec/java_home -V"$version");
         java -version
  }
 ```
@@ -75,7 +75,7 @@ For Fish shell user, add the below function in your `~/.config/fish/functions`
 ```fish
 function jdk
 	set java_version $argv
-	set -Ux JAVA_HOME (/usr/libexec/java_home -v $java_version)
+	set -Ux JAVA_HOME (/usr/libexec/java_home -V $java_version)
 	java -version
 end
 ```


### PR DESCRIPTION
instead `export JAVA_HOME=$(/usr/libexec/java_home -v"$version")` to `export JAVA_HOME=$(/usr/libexec/java_home -V"$version")`

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [ ] Named the cask in a similar way to the existing casks.
- [ ] Added new cask to the README.md
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
