### PR TITLE
Update brew install commands in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,23 +7,23 @@
 To always get the latest and greatest AdoptOpenJDK, run:
 
 ```bash
-$ brew cask install adoptopenjdk
+$ brew install --cask adoptopenjdk
 ```
 
 The `adoptopenjdk` cask will automatically upgrade to the newest patch or major release as soon as it comes out.
 
-To stay with a specific major release, activate the AdoptOpenJDK tap with `brew tap` and then install the desired version with `brew cask install`:
+To stay with a specific major release, activate the AdoptOpenJDK tap with `brew tap` and then install the desired version with `brew install --cask <version>`:
 
 ```bash
 $ brew tap AdoptOpenJDK/openjdk
-$ brew cask install <version>
+$ brew install --cask <version>
 ```
 
 To install AdoptOpenJDK 14 with HotSpot, run:
 
 ```bash
 $ brew tap AdoptOpenJDK/openjdk
-$ brew cask install adoptopenjdk14
+$ brew install --cask adoptopenjdk14
 ```
 
 Multiple major releases can be installed side-by-side. To get a list of available versions, run `brew search adoptopenjdk` or see the [list here in the README](#available-versions).


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->
Updated brew install commands to use `brew install --cask` instead of `brew cask install` to avoid the below warning produced by Homebrew.
`
Warning: Calling brew cask install is deprecated! Use brew install [--cask] instead.
`

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [ ] Named the cask in a similar way to the existing casks.
- [ ] Added new cask to the README.md
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
