### PR TITLE
update: change after_comma before_colon to csv

### DIFF
--- a/Casks/adoptopenjdk10.rb
+++ b/Casks/adoptopenjdk10.rb
@@ -3,45 +3,45 @@ cask "adoptopenjdk10" do
   sha256 "550fac840563073dcfaa1ffd4a3a9cc68fd8ccc71bbc65baf3cb32ec734c30dd"
 
   # github.com/AdoptOpenJDK was verified as official when first introduced to the cask
-  url "https://github.com/AdoptOpenJDK/openjdk10-binaries/releases/download/jdk-10.0.2%2B13.1/OpenJDK10U-jdk_x64_mac_hotspot_10.0.2_13.tar.gz"
-  appcast "https://github.com/adoptopenjdk/openjdk#{version.before_comma}-binaries/releases.atom"
+  url "https://github.com/AdoptOpenJDK/openjdk#{version.major}-binaries/releases/download/jdk-10.0.2%2B13.1/OpenJDK10U-jdk_x64_mac_hotspot_10.0.2_13.tar.gz", verified: "https://github.com/AdoptOpenJDK"
+  appcast "https://github.com/AdoptOpenJDK/openjdk10-binaries/releases/latest"
   name "AdoptOpenJDK 10"
   desc "AdoptOpenJDK OpenJDK (Java) Development Kit"
   homepage "https://adoptopenjdk.net/"
 
   postflight do
     system_command "/bin/mv",
-                   args: ["-f", "--", "#{staged_path}/jdk-#{version.before_comma}.#{version.after_comma.before_colon}+#{version.after_colon}", "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jdk"],
+                   args: ["-f", "--", "#{staged_path}/jdk-10.0.2+13", "/Library/Java/JavaVirtualMachines/adoptopenjdk-10.jdk"],
                    sudo: true
 
     system_command "/bin/mkdir",
-                   args: ["-p", "--", "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jdk/Contents/Home/bundle/Libraries"],
+                   args: ["-p", "--", "/Library/Java/JavaVirtualMachines/adoptopenjdk-10.jdk/Contents/Home/bundle/Libraries"],
                    sudo: true
 
     system_command "/bin/ln",
-                   args: ["-nsf", "--", "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jdk/Contents/Home/lib/server/libjvm.dylib", "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jdk/Contents/Home/bundle/Libraries/libserver.dylib"],
+                   args: ["-nsf", "--", "/Library/Java/JavaVirtualMachines/adoptopenjdk-10.jdk/Contents/Home/lib/server/libjvm.dylib", "/Library/Java/JavaVirtualMachines/adoptopenjdk-10.jdk/Contents/Home/bundle/Libraries/libserver.dylib"],
                    sudo: true
 
     system_command "/usr/libexec/PlistBuddy",
-                   args: ["-c", "Set :CFBundleGetInfoString AdoptOpenJDK #{version.before_comma}+#{version.after_comma}", "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jdk/Contents/Info.plist"],
+                   args: ["-c", "Set :CFBundleGetInfoString AdoptOpenJDK 10+0.2:13", "/Library/Java/JavaVirtualMachines/adoptopenjdk-10.jdk/Contents/Info.plist"],
                    sudo: true
 
     system_command "/usr/libexec/PlistBuddy",
-                   args: ["-c", "Set :CFBundleIdentifier net.adoptopenjdk.#{version.before_comma}.jdk", "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jdk/Contents/Info.plist"],
+                   args: ["-c", "Set :CFBundleIdentifier net.adoptopenjdk.10.jdk", "/Library/Java/JavaVirtualMachines/adoptopenjdk-10.jdk/Contents/Info.plist"],
                    sudo: true
 
     system_command "/usr/libexec/PlistBuddy",
-                   args: ["-c", "Set :CFBundleName AdoptOpenJDK #{version.before_comma}", "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jdk/Contents/Info.plist"],
+                   args: ["-c", "Set :CFBundleName AdoptOpenJDK 10", "/Library/Java/JavaVirtualMachines/adoptopenjdk-10.jdk/Contents/Info.plist"],
                    sudo: true
 
     system_command "/usr/libexec/PlistBuddy",
-                   args: ["-c", "Set :JavaVM:JVMPlatformVersion #{version.before_comma}.#{version.after_comma}", "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jdk/Contents/Info.plist"],
+                   args: ["-c", "Set :JavaVM:JVMPlatformVersion 10.0.2:13", "/Library/Java/JavaVirtualMachines/adoptopenjdk-10.jdk/Contents/Info.plist"],
                    sudo: true
 
     system_command "/usr/libexec/PlistBuddy",
-                   args: ["-c", "Set :JavaVM:JVMVendor AdoptOpenJDK", "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jdk/Contents/Info.plist"],
+                   args: ["-c", "Set :JavaVM:JVMVendor AdoptOpenJDK", "/Library/Java/JavaVirtualMachines/adoptopenjdk-10.jdk/Contents/Info.plist"],
                    sudo: true
   end
 
-  uninstall delete: "/Library/Java/JavaVirtualMachines/adoptopenjdk-#{version.before_comma}.jdk"
+  uninstall delete: "/Library/Java/JavaVirtualMachines/adoptopenjdk-10.jdk"
 end

--- a/Casks/adoptopenjdk10.rb
+++ b/Casks/adoptopenjdk10.rb
@@ -11,35 +11,70 @@ cask "adoptopenjdk10" do
 
   postflight do
     system_command "/bin/mv",
-                   args: ["-f", "--", "#{staged_path}/jdk-10.0.2+13", "/Library/Java/JavaVirtualMachines/adoptopenjdk-10.jdk"],
+                   args: [
+                     "-f",
+                     "--",
+                     "#{staged_path}/jdk-10.0.2+13",
+                     "/Library/Java/JavaVirtualMachines/adoptopenjdk-10.jdk",
+                   ],
                    sudo: true
 
     system_command "/bin/mkdir",
-                   args: ["-p", "--", "/Library/Java/JavaVirtualMachines/adoptopenjdk-10.jdk/Contents/Home/bundle/Libraries"],
+                   args: [
+                     "-p",
+                     "--",
+                     "/Library/Java/JavaVirtualMachines/adoptopenjdk-10.jdk/Contents/Home/bundle/Libraries",
+                   ],
                    sudo: true
 
     system_command "/bin/ln",
-                   args: ["-nsf", "--", "/Library/Java/JavaVirtualMachines/adoptopenjdk-10.jdk/Contents/Home/lib/server/libjvm.dylib", "/Library/Java/JavaVirtualMachines/adoptopenjdk-10.jdk/Contents/Home/bundle/Libraries/libserver.dylib"],
+                   args: [
+                     "-nsf",
+                     "--",
+                     "/Library/Java/JavaVirtualMachines/adoptopenjdk-10.jdk/Contents/Home/lib/server/libjvm.dylib",
+                     "/Library/Java/JavaVirtualMachines/adoptopenjdk-10.jdk/\
+                     Contents/Home/bundle/Libraries/libserver.dylib",
+                   ],
                    sudo: true
 
     system_command "/usr/libexec/PlistBuddy",
-                   args: ["-c", "Set :CFBundleGetInfoString AdoptOpenJDK 10+0.2:13", "/Library/Java/JavaVirtualMachines/adoptopenjdk-10.jdk/Contents/Info.plist"],
+                   args: [
+                     "-c",
+                     "Set :CFBundleGetInfoString AdoptOpenJDK 10+0.2:13",
+                     "/Library/Java/JavaVirtualMachines/adoptopenjdk-10.jdk/Contents/Info.plist",
+                   ],
                    sudo: true
 
     system_command "/usr/libexec/PlistBuddy",
-                   args: ["-c", "Set :CFBundleIdentifier net.adoptopenjdk.10.jdk", "/Library/Java/JavaVirtualMachines/adoptopenjdk-10.jdk/Contents/Info.plist"],
+                   args: [
+                     "-c",
+                     "Set :CFBundleIdentifier net.adoptopenjdk.10.jdk",
+                     "/Library/Java/JavaVirtualMachines/adoptopenjdk-10.jdk/Contents/Info.plist",
+                   ],
                    sudo: true
 
     system_command "/usr/libexec/PlistBuddy",
-                   args: ["-c", "Set :CFBundleName AdoptOpenJDK 10", "/Library/Java/JavaVirtualMachines/adoptopenjdk-10.jdk/Contents/Info.plist"],
+                   args: [
+                     "-c",
+                     "Set :CFBundleName AdoptOpenJDK 10",
+                     "/Library/Java/JavaVirtualMachines/adoptopenjdk-10.jdk/Contents/Info.plist",
+                   ],
                    sudo: true
 
     system_command "/usr/libexec/PlistBuddy",
-                   args: ["-c", "Set :JavaVM:JVMPlatformVersion 10.0.2:13", "/Library/Java/JavaVirtualMachines/adoptopenjdk-10.jdk/Contents/Info.plist"],
+                   args: [
+                     "-c",
+                     "Set :JavaVM:JVMPlatformVersion 10.0.2:13",
+                     "/Library/Java/JavaVirtualMachines/adoptopenjdk-10.jdk/Contents/Info.plist",
+                   ],
                    sudo: true
 
     system_command "/usr/libexec/PlistBuddy",
-                   args: ["-c", "Set :JavaVM:JVMVendor AdoptOpenJDK", "/Library/Java/JavaVirtualMachines/adoptopenjdk-10.jdk/Contents/Info.plist"],
+                   args: [
+                     "-c",
+                     "Set :JavaVM:JVMVendor AdoptOpenJDK",
+                     "/Library/Java/JavaVirtualMachines/adoptopenjdk-10.jdk/Contents/Info.plist",
+                   ],
                    sudo: true
   end
 

--- a/Casks/adoptopenjdk10.rb
+++ b/Casks/adoptopenjdk10.rb
@@ -32,8 +32,8 @@ cask "adoptopenjdk10" do
                      "-nsf",
                      "--",
                      "/Library/Java/JavaVirtualMachines/adoptopenjdk-10.jdk/Contents/Home/lib/server/libjvm.dylib",
-                     "/Library/Java/JavaVirtualMachines/adoptopenjdk-10.jdk/\
-                     Contents/Home/bundle/Libraries/libserver.dylib",
+                     "/Library/Java/JavaVirtualMachines/adoptopenjdk-10.jdk/" \
+                     "Contents/Home/bundle/Libraries/libserver.dylib",
                    ],
                    sudo: true
 

--- a/Casks/adoptopenjdk11-openj9-jre-large.rb
+++ b/Casks/adoptopenjdk11-openj9-jre-large.rb
@@ -18,7 +18,7 @@ cask "adoptopenjdk11-openj9-jre-large" do
   end
 
   uninstall pkgutil: "net.adoptopenjdk.11-openj9.jre"
-  
+
   caveats do
     discontinued
 

--- a/Casks/adoptopenjdk11-openj9-jre-large.rb
+++ b/Casks/adoptopenjdk11-openj9-jre-large.rb
@@ -6,7 +6,7 @@ cask "adoptopenjdk11-openj9-jre-large" do
   # github.com/AdoptOpenJDK was verified as official when first introduced to the cask
   url "https://github.com/AdoptOpenJDK/openjdk#{version.major}-binaries/releases/download/jdk-11.0.10%2B9_openj9-0.24.0/OpenJDK11U-jre_x64_mac_openj9_macosXL_11.0.10_9_openj9-0.24.0.pkg",
       verified: "https://github.com/AdoptOpenJDK"
-  appcast "https://github.com/AdoptOpenJDK/openjdk#{version.major}-binaries/releases/latest"
+  appcast "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/tag/jdk-11.0.10%2B9_openj9-0.24.0"
   name "AdoptOpenJDK 11 (OpenJ9) (JRE) (XL)"
   desc "AdoptOpenJDK OpenJDK (Java) Development Kit"
   homepage "https://adoptopenjdk.net/"

--- a/Casks/adoptopenjdk15-openj9-jre-large.rb
+++ b/Casks/adoptopenjdk15-openj9-jre-large.rb
@@ -18,7 +18,7 @@ cask "adoptopenjdk15-openj9-jre-large" do
   end
 
   uninstall pkgutil: "net.adoptopenjdk.15-openj9.jre"
-  
+
   caveats do
     discontinued
 

--- a/Casks/adoptopenjdk15-openj9-large.rb
+++ b/Casks/adoptopenjdk15-openj9-large.rb
@@ -18,7 +18,7 @@ cask "adoptopenjdk15-openj9-large" do
   end
 
   uninstall pkgutil: "net.adoptopenjdk.15-openj9.jdk"
-  
+
   caveats do
     discontinued
 

--- a/Casks/adoptopenjdk8-jre.rb
+++ b/Casks/adoptopenjdk8-jre.rb
@@ -4,9 +4,9 @@ cask "adoptopenjdk8-jre" do
   sha256 "42a3a7992d46b6d1cf78e56eec11152411d194bbaff7035acde6d00eeb2cec68"
 
   # github.com/AdoptOpenJDK was verified as official when first introduced to the cask
-  url "https://github.com/AdoptOpenJDK/openjdk#{version.before_comma}-binaries/releases/download/jdk8u292-b10/OpenJDK8U-jre_x64_mac_hotspot_8u292b10.pkg",
+  url "https://github.com/AdoptOpenJDK/openjdk#{version.csv.first}-binaries/releases/download/jdk8u292-b10/OpenJDK8U-jre_x64_mac_hotspot_8u292b10.pkg",
       verified: "https://github.com/AdoptOpenJDK"
-  appcast "https://github.com/adoptopenjdk/openjdk#{version.before_comma}-binaries/releases/latest"
+  appcast "https://github.com/adoptopenjdk/openjdk8-binaries/releases/latest"
   name "AdoptOpenJDK 8 (JRE)"
   desc "AdoptOpenJDK OpenJDK (Java) Development Kit"
   homepage "https://adoptopenjdk.net/"

--- a/Casks/adoptopenjdk8-openj9-jre-large.rb
+++ b/Casks/adoptopenjdk8-openj9-jre-large.rb
@@ -4,9 +4,9 @@ cask "adoptopenjdk8-openj9-jre-large" do
   sha256 "779400854c10121f35465160df34e9e0c4cee6a036beaffd5d4245206ab37345"
 
   # github.com/AdoptOpenJDK was verified as official when first introduced to the cask
-  url "https://github.com/AdoptOpenJDK/openjdk#{version.before_comma}-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jre_x64_mac_openj9_macosXL_8u282b08_openj9-0.24.0.pkg",
+  url "https://github.com/AdoptOpenJDK/openjdk#{version.csv.first}-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jre_x64_mac_openj9_macosXL_8u282b08_openj9-0.24.0.pkg",
       verified: "https://github.com/AdoptOpenJDK"
-  appcast "https://github.com/adoptopenjdk/openjdk#{version.before_comma}-binaries/releases/latest"
+  appcast "https://github.com/adoptopenjdk/openjdk8-binaries/releases/latest"
   name "AdoptOpenJDK 8 (OpenJ9) (JRE) (XL)"
   desc "AdoptOpenJDK OpenJDK (Java) Development Kit"
   homepage "https://adoptopenjdk.net/"

--- a/Casks/adoptopenjdk8-openj9-jre.rb
+++ b/Casks/adoptopenjdk8-openj9-jre.rb
@@ -4,9 +4,9 @@ cask "adoptopenjdk8-openj9-jre" do
   sha256 "567e3a5062070f1218c3f4e0275d5287aface76190dcce8419240a1cbcac6f9d"
 
   # github.com/AdoptOpenJDK was verified as official when first introduced to the cask
-  url "https://github.com/AdoptOpenJDK/openjdk#{version.before_comma}-binaries/releases/download/jdk8u292-b10_openj9-0.26.0/OpenJDK8U-jre_x64_mac_openj9_8u292b10_openj9-0.26.0.pkg",
+  url "https://github.com/AdoptOpenJDK/openjdk#{version.csv.first}-binaries/releases/download/jdk8u292-b10_openj9-0.26.0/OpenJDK8U-jre_x64_mac_openj9_8u292b10_openj9-0.26.0.pkg",
       verified: "https://github.com/AdoptOpenJDK"
-  appcast "https://github.com/adoptopenjdk/openjdk#{version.before_comma}-binaries/releases/latest"
+  appcast "https://github.com/adoptopenjdk/openjdk8-binaries/releases/latest"
   name "AdoptOpenJDK 8 (OpenJ9) (JRE)"
   desc "AdoptOpenJDK OpenJDK (Java) Development Kit"
   homepage "https://adoptopenjdk.net/"

--- a/Casks/adoptopenjdk8-openj9-large.rb
+++ b/Casks/adoptopenjdk8-openj9-large.rb
@@ -4,9 +4,9 @@ cask "adoptopenjdk8-openj9-large" do
   sha256 "1944fac65603460caf8f65eecb58df89dbe00b7dac7b7bfe8e6d2af04e36e7bd"
 
   # github.com/AdoptOpenJDK was verified as official when first introduced to the cask
-  url "https://github.com/AdoptOpenJDK/openjdk#{version.before_comma}-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jdk_x64_mac_openj9_macosXL_8u282b08_openj9-0.24.0.pkg",
+  url "https://github.com/AdoptOpenJDK/openjdk#{version.csv.first}-binaries/releases/download/jdk8u282-b08_openj9-0.24.0/OpenJDK8U-jdk_x64_mac_openj9_macosXL_8u282b08_openj9-0.24.0.pkg",
       verified: "https://github.com/AdoptOpenJDK"
-  appcast "https://github.com/adoptopenjdk/openjdk#{version.before_comma}-binaries/releases/latest"
+  appcast "https://github.com/adoptopenjdk/openjdk8-binaries/releases/latest"
   name "AdoptOpenJDK 8 (OpenJ9) (XL)"
   desc "AdoptOpenJDK OpenJDK (Java) Development Kit"
   homepage "https://adoptopenjdk.net/"

--- a/Casks/adoptopenjdk8-openj9.rb
+++ b/Casks/adoptopenjdk8-openj9.rb
@@ -4,9 +4,9 @@ cask "adoptopenjdk8-openj9" do
   sha256 "fbacebe935e4dc1df0a5a8645ca22c4ad4c3f8c71bf364cad90cff0f243f1e28"
 
   # github.com/AdoptOpenJDK was verified as official when first introduced to the cask
-  url "https://github.com/AdoptOpenJDK/openjdk#{version.before_comma}-binaries/releases/download/jdk8u292-b10_openj9-0.26.0/OpenJDK8U-jdk_x64_mac_openj9_8u292b10_openj9-0.26.0.pkg",
+  url "https://github.com/AdoptOpenJDK/openjdk#{version.csv.first}-binaries/releases/download/jdk8u292-b10_openj9-0.26.0/OpenJDK8U-jdk_x64_mac_openj9_8u292b10_openj9-0.26.0.pkg",
       verified: "https://github.com/AdoptOpenJDK"
-  appcast "https://github.com/adoptopenjdk/openjdk#{version.before_comma}-binaries/releases/latest"
+  appcast "https://github.com/adoptopenjdk/openjdk8-binaries/releases/latest"
   name "AdoptOpenJDK 8 (OpenJ9)"
   desc "AdoptOpenJDK OpenJDK (Java) Development Kit"
   homepage "https://adoptopenjdk.net/"

--- a/Casks/adoptopenjdk8.rb
+++ b/Casks/adoptopenjdk8.rb
@@ -4,9 +4,9 @@ cask "adoptopenjdk8" do
   sha256 "4e200bc752337abc9dbfddf125db6a600f2ec53566f6f119a83036c8242a7672"
 
   # github.com/AdoptOpenJDK was verified as official when first introduced to the cask
-  url "https://github.com/AdoptOpenJDK/openjdk#{version.before_comma}-binaries/releases/download/jdk8u292-b10/OpenJDK8U-jdk_x64_mac_hotspot_8u292b10.pkg",
+  url "https://github.com/AdoptOpenJDK/openjdk#{version.csv.first}-binaries/releases/download/jdk8u292-b10/OpenJDK8U-jdk_x64_mac_hotspot_8u292b10.pkg",
       verified: "https://github.com/AdoptOpenJDK"
-  appcast "https://github.com/adoptopenjdk/openjdk#{version.before_comma}-binaries/releases/latest"
+  appcast "https://github.com/adoptopenjdk/openjdk8-binaries/releases/latest"
   name "AdoptOpenJDK 8"
   desc "AdoptOpenJDK OpenJDK (Java) Development Kit"
   homepage "https://adoptopenjdk.net/"

--- a/Casks/adoptopenjdk9.rb
+++ b/Casks/adoptopenjdk9.rb
@@ -3,7 +3,7 @@ cask "adoptopenjdk9" do
   sha256 "bbe348baab3cca097b77f7fff6c8465858e642ad42c5851bde33a1553ca12653"
 
   # github.com/AdoptOpenJDK was verified as official when first introduced to the cask
-  url "https://github.com/AdoptOpenJDK/openjdk#{version.csv.first}-binaries/releases/download/jdk-#{version.csv.first}%2B#{version.csv.second}/OpenJDK#{version.csv.first}U-jdk_x64_mac_hotspot_#{version.csv.first}_#{version.csv.second}.tar.gz"
+  url "https://github.com/AdoptOpenJDK/openjdk#{version.csv.first}-binaries/releases/download/jdk-#{version.csv.first}%2B#{version.csv.second}/OpenJDK#{version.csv.first}U-jdk_x64_mac_hotspot_#{version.csv.first}_#{version.csv.second}.tar.gz", verified: "https://github.com/AdoptOpenJDK"
   appcast "https://github.com/adoptopenjdk/openjdk#{version.before_comma}-binaries/releases.atom"
   name "AdoptOpenJDK 9"
   desc "AdoptOpenJDK OpenJDK (Java) Development Kit"

--- a/Casks/adoptopenjdk9.rb
+++ b/Casks/adoptopenjdk9.rb
@@ -3,7 +3,7 @@ cask "adoptopenjdk9" do
   sha256 "bbe348baab3cca097b77f7fff6c8465858e642ad42c5851bde33a1553ca12653"
 
   # github.com/AdoptOpenJDK was verified as official when first introduced to the cask
-  url "https://github.com/AdoptOpenJDK/openjdk#{version.before_comma}-binaries/releases/download/jdk-#{version.before_comma}%2B#{version.after_comma}/OpenJDK#{version.before_comma}U-jdk_x64_mac_hotspot_#{version.before_comma}_#{version.after_comma}.tar.gz"
+  url "https://github.com/AdoptOpenJDK/openjdk#{version.csv.first}-binaries/releases/download/jdk-#{version.csv.first}%2B#{version.csv.second}/OpenJDK#{version.csv.first}U-jdk_x64_mac_hotspot_#{version.csv.first}_#{version.csv.second}.tar.gz"
   appcast "https://github.com/adoptopenjdk/openjdk#{version.before_comma}-binaries/releases.atom"
   name "AdoptOpenJDK 9"
   desc "AdoptOpenJDK OpenJDK (Java) Development Kit"


### PR DESCRIPTION
	- jdk11 build require bootjdk10 on macos
	- since no more newer version of jdk10 will be released, hardcode version in cask
	- must use variable version in url to by pass audit check

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [ ] Named the cask in a similar way to the existing casks.
- [ ] Added new cask to the README.md
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.

ref: https://github.com/adoptium/infrastructure/issues/2693 