### PR TITLE
User newer livecheck stanza

### DIFF
--- a/Templates/adoptopenjdk.rb.tmpl
+++ b/Templates/adoptopenjdk.rb.tmpl
@@ -6,7 +6,7 @@ cask "{cask_name}" do
   # github.com/AdoptOpenJDK was verified as official when first introduced to the cask
   url "{cask_url}",
       verified: "https://github.com/AdoptOpenJDK"
-  appcast "{appcast}"
+  livecheck "{appcast}"
   name "{name}"
   desc "AdoptOpenJDK OpenJDK (Java) Development Kit"
   homepage "https://adoptopenjdk.net/"


### PR DESCRIPTION
Resolves deprecation notice of `appcast`.

```
$ brew upgrade --cask
Warning: Calling the `appcast` stanza is deprecated! Use the `livecheck` stanza instead.
Please report this issue to the adoptopenjdk/openjdk tap (not Homebrew/brew or Homebrew/homebrew-core), or even better, submit a PR to fix it:
  /usr/local/Homebrew/Library/Taps/adoptopenjdk/homebrew-openjdk/Casks/adoptopenjdk11.rb:9
```

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [ ] Named the cask in a similar way to the existing casks.
- [ ] Added new cask to the README.md
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
