### PR TITLE
fixes the deprecated `appcast` stanza in the "adoptopenjdk8" cask and replaces it with the `livecheck` stanza as recommended.

### DIFF
--- a/Casks/adoptopenjdk8.rb
+++ b/Casks/adoptopenjdk8.rb
@@ -6,7 +6,7 @@ cask "adoptopenjdk8" do
   # github.com/AdoptOpenJDK was verified as official when first introduced to the cask
   url "https://github.com/AdoptOpenJDK/openjdk#{version.csv.first}-binaries/releases/download/jdk8u292-b10/OpenJDK8U-jdk_x64_mac_hotspot_8u292b10.pkg",
       verified: "https://github.com/AdoptOpenJDK"
-  appcast "https://github.com/adoptopenjdk/openjdk8-binaries/releases/latest"
+  livecheck "https://github.com/adoptopenjdk/openjdk8-binaries/releases/latest"
   name "AdoptOpenJDK 8"
   desc "AdoptOpenJDK OpenJDK (Java) Development Kit"
   homepage "https://adoptopenjdk.net/"


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [ x ] `brew cask audit --download {{cask_file}}` is error-free.
- [ x ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ x ] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [ ] Named the cask in a similar way to the existing casks.
- [ ] Added new cask to the README.md
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
